### PR TITLE
correction of error in search strategy 2

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -176,7 +176,7 @@ function search_chemical_id(ID::AnyQuery;skip_common_name = false,try_strategies
         re = r"\w+\s+\([\s\w]+\)"     
         if occursin(re,id)
             _id = id |> z->replace(z,")"=>"") |> z->split(z,"(") .|> strip
-            id1,id2 = first(id1),last(id2)
+            id1,id2 = first(_id),last(_id)
             compound_id1,key1 = search_chemical_id(AnyQuery(id1))
             compound_id2,key2 = search_chemical_id(AnyQuery(id2))
             if (compound_id1 == compound_id2) & (key1==key2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,5 +4,7 @@ using Test
 @testset "ChemicalIdentifiers.jl" begin
     res1 = search_chemical("water",nothing)
     res2 =  search_chemical("SMILES=O",nothing)
+    res3 = search_chemical("water (H2O)", nothing)
     @test res1.formula == res2.formula
+    @test res1.formula == res3.formula
 end


### PR DESCRIPTION
For an entry like 'water (H2O)' a search strategy 2 is used which produced an error in 'src/search.jl' line 179.
Also a test of this case is included into 'test/runtests.jl'.