### PR TITLE
Update search.jl to fix search in multiple databases

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -248,7 +248,7 @@ function search_id_impl(id::T,sym::Symbol,::Type{A})::Tuple{Int,Symbol} where {T
         if length(idxs) == 1 #found and element
             compound_id = only(dbidx[idxs])::Int
             search_done = true
-        else
+        elseif length(idxs) > 1
             throw("Search is not unique, multiple matches found for $id in database $dbname, on the $sym column")
         end        
         if search_done


### PR DESCRIPTION
Problem:

- Search only works for compounds contained in the 'short' database. Otherwise an error is thrown from function `search_id_impl()` aborting the search in additional databases
- e.g. compound with CAS 303-38-8 is in the 'long' database, but not the 'short' database:
```
julia> search_chemical((303,38,8))
ERROR: "Search is not unique, multiple matches found for (303, 38, 8) in database short, on the CAS column"
Stacktrace:
 [1] search_id_impl(id::Tuple{Int32, Int16, Int16}, sym::Symbol, #unused#::Type{Arrow.Struct{Tuple{Int32, Int16, Int16}, Tuple{Arrow.Primitive{Int32, Vector{Int32}}, Arrow.Primitive{Int16, Vector{Int16}}, Arrow.Primitive{Int16, Vector{Int16}}}}})
   @ ChemicalIdentifiers ~/.julia/packages/ChemicalIdentifiers/cGF1A/src/search.jl:252
 [2] search_id_impl
   @ ~/.julia/packages/ChemicalIdentifiers/cGF1A/src/search.jl:233 [inlined]
 [3] search_chemical_id
   @ ~/.julia/packages/ChemicalIdentifiers/cGF1A/src/search.jl:200 [inlined]
 [4] search_chemical(query::Tuple{Int64, Int64, Int64}, cache::Dict{String, Any})
   @ ChemicalIdentifiers ~/.julia/packages/ChemicalIdentifiers/cGF1A/src/search.jl:95
 [5] search_chemical(query::Tuple{Int64, Int64, Int64})
   @ ChemicalIdentifiers ~/.julia/packages/ChemicalIdentifiers/cGF1A/src/search.jl:78
 [6] top-level scope
   @ REPL[14]:1
```

Solution:
- replacing the `else` case with `elseif length(idxs) > 1` to avoid a thrown error for the case of `length(idxs) = 0` (nothing found)